### PR TITLE
#38 ensure that headers and status code get written

### DIFF
--- a/v2/response.go
+++ b/v2/response.go
@@ -92,6 +92,9 @@ func (w *ResponseWriter) End() events.APIGatewayV2HTTPResponse {
 	w.out.Cookies = w.header["Set-Cookie"]
 	w.header.Del("Set-Cookie")
 
+	// ensure headers are written out
+	w.Write([]byte{})
+
 	// notify end
 	w.closeNotifyCh <- true
 

--- a/v2/response_test.go
+++ b/v2/response_test.go
@@ -105,3 +105,12 @@ func TestResponseWriter_WriteHeader(t *testing.T) {
 	assert.Equal(t, "Not Found\n", e.Body)
 	assert.Equal(t, "text/plain; charset=utf8", e.Headers["Content-Type"])
 }
+
+func TestResponseWriter_WriteHeadersWhenEmpty(t *testing.T) {
+	w := NewResponse()
+	w.Header().Set("Content-Type", "text/xml")
+
+	e := w.End()
+	assert.Equal(t, 200, e.StatusCode)
+	assert.Equal(t, "text/xml", e.Headers["Content-Type"])
+}


### PR DESCRIPTION
Ensure that headers and status code get written, even if nothing was ever written. This better aligns with the golang http package's own behavior to write on close.